### PR TITLE
修复 `刷机-GSI` 页面指向错误的问题

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ nav:
           - 线刷: Root/Wirebrush.md
           - 卡刷: Root/Brushcard.md
           - 深刷: Root/Deep.md
-          - GSI: Root/GSI.md
+          - GSI: Root/Gsi.md
           - 救砖: Root/Savebrick.md
           - Huawei: Root/Huawei.md
     - 优化: optimize.md


### PR DESCRIPTION
页面 `刷机-GSI` 被错误地指向到GSI.md（实际文件名为Gsi.md），导致页面无法打开